### PR TITLE
Add task to build biography and add rename task to jekyll

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -185,6 +185,12 @@ desc "Rename all .html files in _site to .md instead."
   end
 end
 
+#### BIO
+task :bio do
+desc "Build biography latex temporary file and place it into Books folder"
+  system "pandoc --latex-engine=xelatex -o Books/bio.tex Source/_includes/bio.md"
+end
+
 #### EPUB
 task :epub, [:book] do |task, args|
 
@@ -259,8 +265,7 @@ desc "Create Smashwords epub versions of our book(s)."
 
 Rake::Task[:jekyll].invoke
 Rake::Task[:rename].invoke
-
-system "pandoc --latex-engine=xelatex -o Books/bio.tex Source/_includes/bio.md"
+Rake::Task[:bio].invoke
 
   if "#{args.book}" == "all"
     filelist = Rake::FileList["_site/*/*-pdf*"]
@@ -283,7 +288,6 @@ desc "Create Smashwords epub versions of our book(s)."
 Rake::Task[:jekyll].invoke
 Rake::Task[:rename].invoke
 
-system "pandoc --latex-engine=xelatex -o Books/bio.tex Source/_includes/bio.md"
 
   if "#{args.book}" == "all"
     filelist = Rake::FileList["_site/*/*-pdf*"]
@@ -305,8 +309,7 @@ desc "Create Smashwords epub versions of our book(s)."
 
 Rake::Task[:jekyll].invoke
 Rake::Task[:rename].invoke
-
-system "pandoc --latex-engine=xelatex -o Books/bio.tex Source/_includes/bio.md"
+Rake::Task[:bio].invoke
 
   if "#{args.book}" == "all"
     filelist = Rake::FileList["_site/*/*-pdf*"]

--- a/Rakefile
+++ b/Rakefile
@@ -175,6 +175,7 @@ end
 task :jekyll do
 desc "Jekyll is muxing our markdown."
   system "bundle exec jekyll build"
+  Rake::Task[:rename].invoke
 end
 
 #### RENAME
@@ -195,7 +196,6 @@ end
 task :epub, [:book] do |task, args|
 
 Rake::Task[:jekyll].invoke
-Rake::Task[:rename].invoke
     
 desc "Create epub versions of our book(s)."
   if "#{args.book}" == "all"
@@ -216,7 +216,6 @@ end
 task :smashwords, [:book] do |task, args|
     
 Rake::Task[:jekyll].invoke
-Rake::Task[:rename].invoke
     
 desc "Create Smashwords epub versions of our book(s)."
   if "#{args.book}" == "all"
@@ -237,7 +236,6 @@ end
 task :amazon, [:book] do |task, args|
     
 Rake::Task[:jekyll].invoke
-Rake::Task[:rename].invoke
     
 desc "Create Amazon mobi versions of our book(s)."
   if "#{args.book}" == "all"
@@ -264,7 +262,6 @@ task :print, [:book] do |task, args|
 desc "Create Smashwords epub versions of our book(s)."
 
 Rake::Task[:jekyll].invoke
-Rake::Task[:rename].invoke
 Rake::Task[:bio].invoke
 
   if "#{args.book}" == "all"
@@ -286,7 +283,6 @@ task :print, [:book] do |task, args|
 desc "Create Smashwords epub versions of our book(s)."
 
 Rake::Task[:jekyll].invoke
-Rake::Task[:rename].invoke
 
 
   if "#{args.book}" == "all"
@@ -308,7 +304,6 @@ task :pdf, [:book] do |task, args|
 desc "Create Smashwords epub versions of our book(s)."
 
 Rake::Task[:jekyll].invoke
-Rake::Task[:rename].invoke
 Rake::Task[:bio].invoke
 
   if "#{args.book}" == "all"
@@ -331,7 +326,6 @@ desc "Create all versions of our book(s)."
 
   if "#{args.book}" == "all"
     Rake::Task[:jekyll].invoke
-    Rake::Task[:rename].invoke
     Rake::Task[:epub].invoke("all")
     Rake::Task[:smashwords].invoke("all")
     Rake::Task[:amazon].invoke("all")
@@ -339,7 +333,6 @@ desc "Create all versions of our book(s)."
     Rake::Task[:pdf].invoke("all")
   else
     Rake::Task[:jekyll].invoke
-    Rake::Task[:rename].invoke
     Rake::Task[:epub].invoke("#{args.book}")
     Rake::Task[:smashwords].invoke("#{args.book}")
     Rake::Task[:amazon].invoke("#{args.book}")


### PR DESCRIPTION
There is some possible optimization in building of the biography if it
is presented as task. It exposes that Books folder is not actually
purely output folder, because `bio.tex` is just a temporary file.

Task rename is always called after jekyll task, so just call it in jekyll task instead and save a lot of complications when you try to figure out why you cant see proper output from jekyll task (you see html while you expect markdown based on the comments of using jekyll to compile one long markdown).